### PR TITLE
fix(deps): resolve @isaacs/brace-expansion DoS vulnerability (GHSA-7h2j-956f-4vf2) #COMW-127

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "typescript": "^5.2.2"
   },
   "resolutions": {
+    "@isaacs/brace-expansion": "5.0.1",
     "@types/react": "^18.2.44",
     "node-gyp": "12.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,12 +1902,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+"@isaacs/brace-expansion@npm:5.0.1":
+  version: 5.0.1
+  resolution: "@isaacs/brace-expansion@npm:5.0.1"
   dependencies:
     "@isaacs/balanced-match": ^4.0.1
-  checksum: d7a3b8b0ddbf0ccd8eeb1300e29dd0a0c02147e823d8138f248375a365682360620895c66d113e05ee02389318c654379b0e538b996345b83c914941786705b1
+  checksum: 21f8192f022c320f7acf899730feb419b1a5f4ccc741481ef8f4b3111e97a41c06e5783871bb240da2e87de909c7fc5b0d07f73818db521fee06541c086ea351
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

Address GHSA-7h2j-956f-4vf2: `@isaacs/brace-expansion` <= 5.0.0 is vulnerable to DoS via unbounded brace range expansion. Malicious patterns can cause exponential CPU/memory use and crash the Node.js process. The vulnerable package is used transitively in the dev/build toolchain (jest, metro, fsevents, node-gyp).

## Intended outcome

- Mitigate the DoS vulnerability in the SDK repo's dev/build environment.
- Ensure `yarn install` and native module builds use the patched `@isaacs/brace-expansion@5.0.1`.

## Overview of changes

- Added Yarn resolution `"@isaacs/brace-expansion": "5.0.1"` in `package.json`.
- Updated `yarn.lock` so `@isaacs/brace-expansion` resolves to 5.0.1 instead of 5.0.0.

## Quality assurance
Completed by Cursor:
- [x] `yarn install` — completed successfully
- [x] `yarn test` — passed
- [x] `yarn typecheck` — passed
- [x] `yarn prepare` (bob build) — passed (commonjs, module, typescript)
- [x] Metro bundler — started successfully

**Risk:** Low. Change is a patch-level upgrade within the existing semver range (`^5.0.0`). No SDK release required; the fix only affects the repo's dev/build toolchain.